### PR TITLE
⚡ Bolt: [performance improvement] Integer exponentiation for small powers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/
+__pycache__/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-23 - Integer Exponentiation
+**Learning:** Avoid using floating point exponentiation for small integer powers like `**2.0_wp`. Fortran converts this into expensive math library calls like `exp(y * log(x))`.
+**Action:** Replace `**2.0_wp` and `**3.0_wp` with `**2` and `**3`.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 What: Replaced floating-point exponentiation (e.g., `**2.0_wp` and `**3.0_wp`) with integer exponentiation (e.g., `**2` and `**3`) in `source/two_body_potentials.F90` and `source/integrators.F90`.

🎯 Why: In Fortran, small floating-point exponentiation is converted into expensive math library calls like `exp(y * log(x))`. Integer exponentiation uses simple multiplication, making the execution of these hot loops significantly faster.

📊 Impact: Lowers computational overhead for molecular dynamics calculations by avoiding complex `math.h` library calls for common integer powers. Expected minimal positive impact on overall calculation times without compromising accuracy.

🔬 Measurement: Verify tests run successfully using `ctest -R U00` to ensure calculation logic remains equivalent.

---
*PR created automatically by Jules for task [5215870465970648320](https://jules.google.com/task/5215870465970648320) started by @alinelena*