### PR TITLE
⚡ Bolt: [performance improvement] Fortran Exponentiation Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-13 - Fortran Exponentiation Optimization
+**Learning:** Fortran's `**` operator behaves differently depending on whether the exponent is an integer or a real number. `x**2` (integer exponent) translates to `x * x`, while `x**2.0` (real exponent) translates to `exp(2.0 * log(x))`, which is significantly slower due to math library function calls. The same applies for `.0_wp` kinds.
+**Action:** Replace `**2.0_wp` with `**2` and `**3.0_wp` with `**3` in exponentiations.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 **2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 **2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 **3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 **What:** 
Replaced occurrences of floating-point exponentiation (`**2.0_wp` and `**3.0_wp`) with integer equivalents (`**2` and `**3`) in `source/two_body_potentials.F90` and `source/integrators.F90`.

🎯 **Why:** 
In Fortran, `x**2.0_wp` forces the compiler to call expensive math library functions `exp(2.0 * log(x))`. Using `x**2` allows the compiler to use direct simple multiplication (`x * x`), preventing unnecessary overhead in the hottest code paths like the integration routines and potential calculations.

📊 **Impact:** 
Expected significant reduction in math library overhead across multiple performance-critical iterations where exponentiation happens continuously.

🔬 **Measurement:** 
Run unit tests with `ctest -R U` from within `build/` to verify tests pass smoothly, and measure wall-time execution to verify any simulation speedup.

---
*PR created automatically by Jules for task [15739551567728660659](https://jules.google.com/task/15739551567728660659) started by @alinelena*