### PR TITLE
⚡ Bolt: [performance improvement] Use integer exponentiation in Fortran modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Fortran Exponentiation Optimization
+**Learning:** In Fortran, floating-point exponentiation (e.g., `x**2.0_wp` or `x**3.0_wp`) is significantly slower than integer exponentiation (e.g., `x**2` or `x**3`) because it uses an expensive math library routine `exp(y * log(x))` instead of a simple multiplication loop or inline multiply instructions.
+**Action:** Always prefer integer types for exponents in Fortran expressions (e.g., `**2`, `**3`) when the exponent is an integer, avoiding `.0_wp` or `.0` suffixes for powers.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 **What:** Replaced floating-point exponentiation (e.g., `x**2.0_wp`, `x**3.0_wp`) with integer exponentiation (e.g., `x**2`, `x**3`) in `source/two_body_potentials.F90` and `source/integrators.F90`.

🎯 **Why:** In Fortran, raising a number to a floating-point power forces the compiler to invoke a costly general-purpose standard math library routine (e.g., `exp(y * log(x))`). Using integer exponents allows the compiler to optimize the operation into simple, fast inline multiplications (`x * x`).

📊 **Impact:** This optimization eliminates significant overhead in tight numerical loops evaluating potentials and integrators, reducing CPU cycles per step without changing the resulting values or logic.

🔬 **Measurement:** Verify by running the full test suite (`cd build && make && ctest -R U`) and comparing simulation execution times on tight loop benchmarks or profilers. Tests were successful locally.

*Note: Documented this performance pattern in `.jules/bolt.md`.*

---
*PR created automatically by Jules for task [12699104295939381202](https://jules.google.com/task/12699104295939381202) started by @alinelena*