### PR TITLE
⚡ Bolt: Optimize Fortran Exponentiation Performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Fortran Exponentiation Performance
+**Learning:** Using floating-point exponentiation (like `x**2.0_wp`) instead of integer exponentiation (`x**2`) causes expensive math library function calls like `exp(y * log(x))`.
+**Action:** Always prefer integer exponentiation (e.g., `x**2` or `x**3`) over floating-point exponentiation in Fortran files.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 **What:** Replaced floating-point exponentiation (like `x**2.0_wp` and `x**3.0_wp`) with integer exponentiation (like `x**2` and `x**3`) in `source/two_body_potentials.F90` and `source/integrators.F90`.

🎯 **Why:** In Fortran, raising a number to a real or floating-point power is often evaluated using expensive math library function calls like `exp(y * log(x))`. Integer exponentiation directly compiles to faster operations (like simple multiplication for small powers).

📊 **Impact:** Reduces computation time in performance-critical code areas involving two-body potentials and integrators, with measurable speedup depending on the workload and without affecting precision.

🔬 **Measurement:** Verify by comparing benchmark times of integrators or large MD simulations before and after the change. Ensure unit tests (`ctest -R U`) still pass.

---
*PR created automatically by Jules for task [11779870834361635980](https://jules.google.com/task/11779870834361635980) started by @alinelena*