### PR TITLE
⚡ Bolt: Optimize Fortran exponentiation for performance

### DIFF
--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1)) ! ⚡ Bolt: Integer exponentiation
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0) ! ⚡ Bolt: Integer exponentiation
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1)) ! ⚡ Bolt: Integer exponentiation
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2 ! ⚡ Bolt: Using integer exponentiation for performance
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2) ! ⚡ Bolt: Using integer exponentiation for performance
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 **What**: Replaced floating-point exponentiation (`**2.0_wp`, `**3.0_wp`) with integer exponentiation (`**2`, `**3`) in `source/two_body_potentials.F90` and `source/integrators.F90`.
🎯 **Why**: For Fortran performance optimization in this codebase, integer exponentiation is significantly faster because it avoids expensive math library function calls like `exp(y * log(x))` which are used for floating-point exponents.
📊 **Impact**: Faster execution in critical code paths (potentials and integrators) by avoiding unnecessary floating-point operations.
🔬 **Measurement**: Run the core simulation tests (`ctest -R U`) to verify functionality is preserved, and profile the simulation for overall speedup. Unit tests have been run and verified to pass.

---
*PR created automatically by Jules for task [3998428152873161031](https://jules.google.com/task/3998428152873161031) started by @alinelena*