### PR TITLE
⚡ Bolt: Use integer exponentiation instead of floating-point for better performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/*

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-11 - Fortran Floating-Point Exponentiation
+**Learning:** Fortran codes often use floating-point exponentiation (e.g., `x**2.0_wp` instead of `x**2`) which calls expensive math library functions like `exp()` and `log()` under the hood instead of simple multiplication. This is a common performance anti-pattern in scientific computing.
+**Action:** Always search for floating-point exponents like `**2.0` or `**3.0` and replace them with integer exponents (`**2`, `**3`) to avoid unnecessary generic math library calls.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,10 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        ! ⚡ Bolt: Use integer exponentiation for better performance
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,13 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    ! ⚡ Bolt: Use integer exponentiation for better performance
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    ! ⚡ Bolt: Use integer exponentiation for better performance
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 What: Replaced floating-point exponentiation (e.g., `**2.0_wp`) with integer exponentiation (e.g., `**2`) in `two_body_potentials.F90` and `integrators.F90`.
🎯 Why: In Fortran, integer exponentiation is evaluated via simple multiplication (e.g., `x * x`), whereas floating-point exponentiation invokes computationally expensive generic math library routines (like `exp(2.0 * log(x))`). This is a classic performance anti-pattern in scientific computing.
📊 Impact: Expected performance improvement in heavily used loops within the potential energy and integrator calculations, reducing CPU cycles per step.
🔬 Measurement: Verify the improvement by running a molecular dynamics benchmark and profiling the time spent in `sanderson_energy` and `simpsons_rule_non_uniform` routines, or by observing an overall reduction in simulation time.

---
*PR created automatically by Jules for task [14455489471783599521](https://jules.google.com/task/14455489471783599521) started by @alinelena*