### PR TITLE
⚡ Bolt: Replace floating-point with integer exponentiation for performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-17 - Floating Point Exponentiation in Fortran
+**Learning:** In Fortran, floating-point exponentiation (e.g., `x ** 2.0_wp`) can be significantly slower than integer exponentiation (e.g., `x ** 2`) because the former often invokes the math library's `pow` or `exp(log())` functions, whereas the latter translates to direct multiplication.
+**Action:** Always prefer integer exponents for powers like 2, 3, 4, etc., to avoid unnecessary overhead in hot paths like integrators and potential calculations.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 What: Changed instances of `** 2.0_wp` and `** 3.0_wp` to `** 2` and `** 3` in `source/integrators.F90` and `source/two_body_potentials.F90`.
🎯 Why: In Fortran, floating-point exponentiation is evaluated using expensive calls to `pow()` or `exp(log())`, while integer exponentiation translates to fast direct multiplication. This optimization prevents unnecessary math library overhead in high-frequency mathematical paths like numerical integration and potential energy calculation.
📊 Impact: Expected to slightly improve core calculation performance during molecular dynamics simulations by reducing the CPU cycles spent on exponentiation.
🔬 Measurement: Verified that all unit tests (`ctest -R U`) continue to pass without error, indicating no change to functional correctness.

---
*PR created automatically by Jules for task [7665194015121478559](https://jules.google.com/task/7665194015121478559) started by @alinelena*