### PR TITLE
⚡ Bolt: [performance improvement] Use integer exponentiation for small powers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh
+!build/CMakeLists.txt

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## YYYY-MM-DD - [Title]
+
+## 2026-06-18 - Prefer integer exponentiation over floating-point
+**Learning:** In Fortran, evaluating mathematical expressions with small integer powers (like x**2 or x**3) using floating point representations of the exponent (like `x**2.0_wp`) is a common anti-pattern in this codebase. Floating-point exponentiation is evaluated using expensive math library calls like `exp(y * log(x))` which slows down computationally intensive inner loops. Moreover, evaluating negative bases with floating-point exponents can cause NaN errors or exceptions in Fortran.
+**Action:** Always prefer integer exponentiation (`x**2`) instead of floating-point exponents (`x**2.0`) for small integer powers to ensure they are evaluated efficiently via simple multiplications.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,10 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        ! Bolt: optimized exponentiation (**2.0_wp to **2, **3.0_wp to **3) to avoid expensive floating-point math
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,12 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    ! Bolt: optimized exponentiation (**2.0_wp to **2) to avoid expensive floating-point exp(y*log(x))
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 **What**: Replaced instances of floating-point exponentiation (e.g., `**2.0_wp`, `**3.0_wp`) with integer exponentiation (e.g., `**2`, `**3`) in `source/two_body_potentials.F90` and `source/integrators.F90`.

🎯 **Why**: In Fortran, floating-point exponentiation for small powers evaluates using expensive math library functions like `exp(y * log(x))`. Integer exponentiation simply expands to multiplications (e.g. `x * x`), which is significantly faster and also safer, since evaluating negative bases with floating-point exponents can cause NaN errors or exceptions. This impacts tight loops like the potential generation and integrators.

📊 **Impact**: Faster execution of math-heavy inner loops and numerical integrators, with lower risk of edge-case domain errors.

🔬 **Measurement**: Verify by profiling unit tests (`ctest -R U`) or integration tasks that stress the numerical integrators and two-body potential calculation routines. Tests have been run locally to ensure no regressions.

---
*PR created automatically by Jules for task [14695444535171644386](https://jules.google.com/task/14695444535171644386) started by @alinelena*