### PR TITLE
⚡ Bolt: [performance improvement] Optimize Fortran exponentiation in two_body_potentials and integrators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Fortran Exponentiation Optimization
+**Learning:** In Fortran, float exponentiation like x**2.0_wp uses an expensive generic floating point algorithm such as exp(y * log(x)), while integer exponentiation x**2 relies on efficient multiplication (e.g. x * x). This is significantly faster.
+**Action:** Whenever possible, use integer constants for small, fixed exponents in Fortran instead of floating point constants (e.g., x**2 instead of x**2.0_wp or x**2.0). Also, applying floating point exponents to negative bases can produce NaN due to log evaluation, so integer exponents avoid stability issues.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,10 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        ! Bolt: optimized by replacing **2.0_wp and **3.0_wp with integer exponents **2 and **3 for faster computation
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,13 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    ! Bolt: optimized by replacing **2.0_wp with integer exponent **2 for faster computation
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    ! Bolt: optimized by replacing **2.0_wp with integer exponent **2 for faster computation
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 What: Replaced floating-point exponentiation `**2.0_wp` and `**3.0_wp` with integer exponentiation `**2` and `**3` in `source/two_body_potentials.F90` and `source/integrators.F90`.
🎯 Why: In Fortran, float exponentiation uses expensive math libraries (e.g. `exp(y * log(x))`), while integer exponents rely on significantly faster direct multiplication loops.
📊 Impact: Expected reduction in computation time within integral algorithms and two-body potential energy calculations.
🔬 Measurement: Run unit tests using `cd build && make test ARGS="-R U"` and profile the integrators execution path over many iterations.

---
*PR created automatically by Jules for task [621322228075395129](https://jules.google.com/task/621322228075395129) started by @alinelena*