### PR TITLE
⚡ Bolt: [performance improvement] Optimize exponentiation in two_body_potentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Fortran Exponentiation Optimization
+**Learning:** In this Fortran codebase, using floating-point exponentiation (e.g., `**2.0_wp`) for integer powers causes the compiler to invoke expensive math library calls like `exp(y * log(x))` rather than performing simple multiplication, leading to significant performance degradation in hot loops. Additionally, negative bases with floating-point exponents can cause NaN errors or exceptions.
+**Action:** Always prefer integer exponentiation (e.g., `**2` instead of `**2.0_wp`) when calculating integer powers to avoid expensive intrinsic function calls and improve robustness.

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,13 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    ! ⚡ Bolt: replace floating-point exponentiation with integer exponentiation
+    ! to avoid expensive math library calls like exp(y * log(x))
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 What: Replaced floating-point exponentiation (e.g., `**2.0_wp`) with integer exponentiation (e.g., `**2`) in the Sanderson potential calculations in `source/two_body_potentials.F90`.
🎯 Why: In Fortran, using a real number for an integer power forces the compiler to use expensive intrinsic functions like `exp(y * log(x))` instead of a simple multiplication. Using integer exponents ensures the fast path (simple multiplication) is taken.
📊 Impact: Expected to reduce execution time in the critical hot loops evaluating two-body potentials, avoiding the overhead of expensive math library function calls and improving robustness by eliminating potential NaN errors when bases are negative.
🔬 Measurement: Verify by running standard unit tests `cd build && make -j4 && ctest -R U` and benchmarking standard potential evaluation. All unit tests passed.

---
*PR created automatically by Jules for task [11712438315768354553](https://jules.google.com/task/11712438315768354553) started by @alinelena*