### PR TITLE
⚡ Bolt: [performance improvement] Replace floating-point exponentiation with integer exponentiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Integer vs Floating-Point Exponentiation in Fortran
+**Learning:** Fortran evaluates floating-point exponents (e.g., `x**2.0_wp`) using expensive math library function calls like `exp(y * log(x))`. Furthermore, evaluating negative bases with floating-point exponents can cause NaN errors or exceptions in Fortran.
+**Action:** Prefer integer exponentiation (e.g., `x**2` or `x**3`) over floating-point exponentiation for whole number powers to improve performance and code robustness.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
**💡 What:**
Replaced usages of floating-point exponentiation (e.g., `x**2.0_wp` or `x**3.0_wp`) with integer exponentiation (e.g., `x**2` or `x**3`) in `source/two_body_potentials.F90` and `source/integrators.F90`. Ignored the generated CMake artifacts in `.gitignore`. Recorded the learning in `.jules/bolt.md`.

**🎯 Why:**
Fortran evaluates floating-point exponents using expensive math library function calls like `exp(y * log(x))`. Integer exponentiation directly evaluates via standard multiplication for low integer powers (e.g., `x * x` for `x**2`). This simple switch avoids the expensive math calls entirely. Additionally, this prevents NaN exceptions in scenarios where floating point inaccuracies could lead to slightly negative bases being passed into floating point exponents.

**📊 Impact:**
Improves execution performance in high-frequency mathematical evaluations within core potential logic (`two_body_potentials.F90`) and mathematical integrators (`integrators.F90`). Reduces likelihood of NaN generation.

**🔬 Measurement:**
Tested via successful execution of unit test suite using `ctest -R U`. Performance impact would be measurable via profiling or during extended molecular dynamics simulations using standard benchmark suites.

---
*PR created automatically by Jules for task [9967963102326742937](https://jules.google.com/task/9967963102326742937) started by @alinelena*