### PR TITLE
⚡ Bolt: Optimize Fortran exponentiation for better performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Fortran Exponentiation Performance
+**Learning:** In Fortran, integer exponentiation (e.g., `x**2`) is significantly faster than floating-point exponentiation (e.g., `x**2.0_wp`). Floating-point exponentiation forces the compiler to call costly math library functions like `exp(y * log(x))`, whereas integer exponentiation compiles down to simple multiplications (e.g., `x*x`). Furthermore, evaluating negative bases with floating-point exponents can cause NaN errors or exceptions in Fortran.
+**Action:** Always prefer integer exponents (e.g., `**2` instead of `**2.0_wp`) in performance-critical Fortran routines such as those calculating integrators or potentials.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 **What**: Replaced floating-point exponentiation (e.g., `**2.0_wp`) with integer exponentiation (e.g., `**2`) in inner loops of `source/two_body_potentials.F90` and `source/integrators.F90`.

🎯 **Why**: In Fortran, exponentiation by a floating-point number forces the compiler to call expensive math library functions like `exp(y * log(x))`. Integer exponentiation compiles down directly into fast multiplication operations (e.g., `x * x`), which are significantly faster.

📊 **Impact**: This change speeds up critical paths such as energy potential and integration calculations by removing unnecessary overhead.

🔬 **Measurement**: Run the unit test suite (`ctest -R U`) to verify functionality. Performance improvements can be measured by running intensive molecular dynamics simulations and profiling the time spent in `simpsons_rule_non_uniform` and potential evaluation.

---
*PR created automatically by Jules for task [6106687105732485934](https://jules.google.com/task/6106687105732485934) started by @alinelena*