### PR TITLE
⚡ Bolt: [performance improvement] Replace floating-point exponentiation with integer exponentiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Integer Exponentiation over Floating Point
+**Learning:** In Fortran, integer exponentiation (e.g. `x**2`) is evaluated differently from floating-point exponentiation (e.g. `x**2.0_wp`). Floating point powers involve calling the math library (`exp(y * log(x))`), which can be computationally expensive and unstable for negative bases.
+**Action:** When a power is known to be a small integer, always write it as an integer literal rather than a real variable to avoid performance penalty and ensure robust mathematical behavior.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 What: Replaced floating-point exponentiation (e.g., `x**2.0_wp`) with integer exponentiation (e.g., `x**2`) where the exponent is a small, known integer in `source/two_body_potentials.F90` and `source/integrators.F90`.

🎯 Why: In Fortran, raising a number to a real/floating-point power invokes expensive library math functions like `exp(y * log(x))`. Raising to an integer power uses simple, extremely fast, consecutive multiplications. This improves the performance in hot path routines like two-body potential energy calculations and numeric integrators.

📊 Impact: Decreases computational overhead and math library function calls per simulation timestep, leading to a faster and more efficient simulation without sacrificing readability.

🔬 Measurement: Verifiable by executing unit tests using `cd build && cmake .. -DBUILD_TESTING=ON && make -j4 && ctest -R U`. Unit tests passed successfully. The resulting calculations are mathematically identical and avoid any potential floating-point robustness issues with negative bases.

---
*PR created automatically by Jules for task [14863331317947933160](https://jules.google.com/task/14863331317947933160) started by @alinelena*