### PR TITLE
⚡ Bolt: Use integer exponentiation for performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Avoid Floating Point Exponentiation
+**Learning:** In this Fortran codebase, using floating-point exponents like `**2.0_wp` instead of integer exponents like `**2` forces the compiler to use expensive math library calls like `exp(y * log(x))` and makes it susceptible to `NaN` errors on negative bases.
+**Action:** Always replace floating-point exponentiation with integer exponentiation for integers constants to get better performance.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,10 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        ! Bolt: Using integer exponentiation (**2, **3 instead of **2.0_wp, **3.0_wp) avoids expensive math library calls
+        v = v + f(Size(f))   * (2.0_wp * h1 **2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 **2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 **3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,12 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    ! Bolt: Using integer exponentiation (**2 instead of **2.0_wp) avoids expensive math library calls
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 What: Replaced floating-point exponentiation (e.g., `**2.0_wp`) with integer exponentiation (e.g., `**2`) in `two_body_potentials.F90` and `integrators.F90`.
🎯 Why: Floating point exponentiation causes expensive math library function calls like `exp(y * log(x))`. Integer exponentiation avoids this and prevents potential `NaN` errors.
📊 Impact: Avoids expensive math library function calls like `exp(y * log(x))` and improves robustness against `NaN` errors.
🔬 Measurement: Rebuilding and running the core unit tests verified functional equivalence.

---
*PR created automatically by Jules for task [8806012857216334155](https://jules.google.com/task/8806012857216334155) started by @alinelena*