### PR TITLE
⚡ Bolt: Replace floating point exponents with integer exponents for speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh
+!build/install-kim.sh
+!build/install-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-13 - Replace Floating-Point Exponents With Integer Exponents
+**Learning:** Found several places where `**2.0_wp` or `**3.0_wp` are used in performance-critical areas like `sanderson_energy` (in `two_body_potentials.F90`) and Simpson integration rules (`integrators.F90`). In Fortran, float-based exponentiation triggers expensive generic math library function calls (often `exp(y * log(x))`), while integer exponents (`**2` or `**3`) usually compile into simpler inline multiplications.
+**Action:** Replace these `**.0_wp` literals with integer counterparts (`**2` or `**3`) for faster execution.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 **What**: Replaced instances of floating-point exponentiation (like `**2.0_wp` or `**3.0_wp`) with integer exponentiation (like `**2` or `**3`) in `source/two_body_potentials.F90` and `source/integrators.F90`.
🎯 **Why**: In Fortran, float-based exponentiation triggers expensive generic math library function calls (often involving `exp(y * log(x))`), while integer exponents are typically compiled into simpler inline multiplications.
📊 **Impact**: Faster execution of performance-critical paths like the Sanderson energy calculations and the Simpson non-uniform integration rules.
🔬 **Measurement**: Verify improvements by profiling the physics core during a typical MD simulation run or running microbenchmarks directly on the updated Fortran modules. All unit tests pass cleanly after this change.

---
*PR created automatically by Jules for task [7795863754534256](https://jules.google.com/task/7795863754534256) started by @alinelena*