### PR TITLE
⚡ Bolt: [performance improvement] Fortran Integer Exponentiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh
+!build/install-kim.sh
+!build/install-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-20 - Fortran Integer Exponentiation Optimization
+**Learning:** In this Fortran codebase, using integer exponentiation (e.g., `x**2`) is faster and more robust than floating-point exponentiation (e.g., `x**2.0_wp`), which triggers expensive math library function calls like `exp(y * log(x))` and can cause NaN errors with negative bases.
+**Action:** Prefer integer literals for exponents when the power is a whole number to improve computational efficiency.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,10 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        ! ⚡ Bolt: integer exponentiation is much faster than float pow
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,13 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    ! ⚡ Bolt: integer exponentiation is much faster than float pow
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    ! ⚡ Bolt: integer exponentiation is much faster than float pow
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 **What:** Replaced floating-point exponentiation (e.g., `x**2.0_wp`) with integer exponentiation (e.g., `x**2`) in critical computational paths within `source/integrators.F90` and `source/two_body_potentials.F90`.
🎯 **Why:** In Fortran, raising a number to a floating-point power often compiles down to an expensive math library call (like `exp(y * log(x))`), while raising it to an integer power is highly optimized by the compiler into simple multiplications (e.g., `x * x`). This small change provides a free performance boost in tight inner loops without sacrificing precision or readability.
📊 **Impact:** Expected reduction in computational overhead for integration and potential evaluation steps. Micro-benchmark impact is typically significant for these specific operations.
🔬 **Measurement:** Verify by running the unit tests (`ctest -R U`) and comparing simulation times for standard workloads before and after the change. No functional changes; tests still pass.

---
*PR created automatically by Jules for task [6936118701306740409](https://jules.google.com/task/6936118701306740409) started by @alinelena*