### PR TITLE
⚡ Bolt: [performance improvement] Optimize Fortran exponentiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 data/*.tar.xz
 data/reference
 source/*.mod
+build/*
+!build/build-kim.sh
+!build/build-plumed.sh
+!build/install-kim.sh
+!build/install-plumed.sh

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-26 - Use Integer Exponentiation
+**Learning:** In Fortran, integer exponentiation (e.g. `x**2`) should be preferred over floating point exponentiation (e.g. `x**2.0_wp`) to avoid expensive math library calls like `exp(y * log(x))`.
+**Action:** Always check for `**2.0` or similar floating point exponents and convert them to integer exponents when the power is a whole number to improve performance.

--- a/source/integrators.F90
+++ b/source/integrators.F90
@@ -311,9 +311,9 @@ Contains
       If (Mod(n,2) == 1) Then 
         h0 = t(Size(t)-1)-t(Size(t)-2)
         h1 = t(Size(t))-t(Size(t)-1)
-        v = v + f(Size(f))   * (2.0_wp * h1 ** 2.0_wp + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
-        v = v + f(Size(f)-1) * (h1 ** 2.0_wp + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
-        v = v - f(Size(f)-2) * h1 ** 3.0_wp               / (6.0_wp * h0 * (h0 + h1))
+        v = v + f(Size(f))   * (2.0_wp * h1 ** 2 + 3.0_wp * h0 * h1) / (6.0_wp * (h0 + h1))
+        v = v + f(Size(f)-1) * (h1 ** 2 + 3.0_wp * h1 * h0)      / (6.0_wp * h0)
+        v = v - f(Size(f)-2) * h1 ** 3               / (6.0_wp * h0 * (h0 + h1))
       End If
     End If    
   End Function simpsons_rule_non_uniform

--- a/source/two_body_potentials.F90
+++ b/source/two_body_potentials.F90
@@ -1059,11 +1059,11 @@ Contains
 
     L = p%L
     d = p%d
-    b = ((r - L)/d)**2.0_wp
+    b = ((r - L)/d)**2
     t = p%A * Exp(-b)
 
     sanderson_energy%energy = -t
-    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2.0_wp)
+    sanderson_energy%gamma = -2.0_wp*(r-L)*r*t/(d**2)
     If (comp_sec_deriv) Then
       sanderson_energy%delta = 2.0_wp*t*(p%d**2 - 2.0_wp*(r-p%L)**2) / (d**4)
     Else


### PR DESCRIPTION
💡 What: Replaced floating-point exponentiation (e.g., `**2.0_wp`) with integer exponentiation (e.g., `**2`) in numerical integration and potential calculations.
🎯 Why: In Fortran, floating-point exponents call expensive underlying mathematical libraries (e.g., `exp(y * log(x))`), while integer exponentiation uses simple multiplication which is much faster.
📊 Impact: Reduces overhead in numerical integration and energy evaluation loops, which are critical inner loops executed frequently.
🔬 Measurement: Ensure the unit tests pass (`ctest -R U`) which verifies the same outputs are computed without regressions.

---
*PR created automatically by Jules for task [10790120506950371532](https://jules.google.com/task/10790120506950371532) started by @alinelena*